### PR TITLE
Added cross cutting activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ This repository delivers information about science teams and simulations.
 
 ### Contribute to this repo
 
-If you like to take a team lead, please provide a few sentences about your research interest in `./content/scienceteams.md` and a coordination contact. You can simply follow the structure given in `scienceteams.md`.
+If you would like to propose a science team or cross cutting activity, please provide a few sentences about your idea in `./content/scienceteams.md`  respectively `./content/crosscutting.md`, and a coordination contact. You can simply follow the structure given in those respective markdown files. Having done this please make a pull request to have your proposal reviewed.
 
-**To work** in a science team, please check the [repo *hk24-teams*](https://github.com/digital-earths-global-hackathon/hk25-teams.git), where you could find some scripts and jupyternotebooks to start with.
+For those not familiar with the git workflow, you can either propose your team by posting an issue to this repo, or contact one of us. 
+
+**To work** an established science team or cross cutting activity please check [repo *hk24-teams*](https://github.com/digital-earths-global-hackathon/hk25-teams.git) respectively [repo *hk24-activities*](https://github.com/digital-earths-global-hackathon/hk25-activities.git).  There, at the latest by the end of the first day, you will find some scripts and jupyternotebooks and other information needed to get started.
 
 ---
 

--- a/content/crosscutting.md
+++ b/content/crosscutting.md
@@ -1,0 +1,68 @@
+---
+header_menu: false
+---
+
+# Cross cutting activities
+
+A number of ambitious cross cutting activities are also planned.  These usually introduce or explore technical capabilities that might be useful for addressing a range of scientific questions.  For this reason we are setting up cross-cutting activities whose participants may also want to join a science team. Some of the activities require early registration to ensure timely access to the tools.
+
+Activities are given a unique identifier (uid) following the convention ‘hk25-uid’. Each activity will also have a lead and an associated repo on github with the same uid. The repo will serve as the primary basis for communication among participants in an activity.  Mattermost channels, markdown pads, and video-conference links may also serve as supplemental forms of communications, as indicated on by the README for each activity.
+
+---
+### Joint EarthCARE analysis with ESA ([hk25-EarthCARE](https://github.com/digital-earths-global-hackathon/hk25-teams/tree/main/hk25-EarthCARE))
+
+[EarthCARE](https://earth.esa.int/eogateway/missions/earthcare) is a satellite, developed by ESA, JAXA and NICT and is the sixth satellite choosen as part of ESA's Earth Explorer Programme.   It was launched on 28 May 2024, and be completing its first year in orbit at the time of the Hackathon.  It has unusual capabilities for measuring clouds, aerosols, and radiation.
+
+In this team we will analyze both EarthCARE data and the participating models along virtual EarthCARE swaths, with an initial focus on tropical deep convection as analyzed by EarthCARE, aircraft, ships and ground stations during the [ORCESTRA campaign](http://orcestra-campaign.org/), i.e., over the Tropical Atlantic in the time-period between 10 August and 30 September.
+
+**Coordination**: Bjorn Stevens (bjorn.stevens@mpimet.mpg.de)
+
+#### Sketch of initial activities:
+* extract model output along selected orbit frames
+* post-process output using model simulators
+* extract analagous EarthCARE frames and data from reanalyses.
+* perform composit analysis of various quantities.
+
+---
+### Destination Earth with ECMWF ([hk25-DestinE](https://github.com/digital-earths-global-hackathon/hk25-teams/tree/main/hk25-DestinE))
+
+[DestineE](https://destination-earth.eu) is a an initiative of the European Commission which includes the operational provision of climate scenarios based on km-scale global models. Several multi-decadal senario simulations have been performed and are being integrated into a DestinE data platform. 
+
+In this cross-cutting activity we will adopt analyses of different science teams to the DestinE data.  One of the goals of this activity is to experiment with the capabilities of the [DestinE data platform](https://platform.destine.eu) to highlight its capabilities and bottlenecks. Another is expand the scope of the scientific analysis being performed by the science teams and begin exploring the propoerties of the DestinE models.. 
+
+**Note** Special access to the DestinE data platform is being granted to participants in the Hackathon.  However those wishing to gain access need to register by 2 May, and abide by the DestinE data policies. 
+
+**Coordination**: Theresa Kiszler and Thomas Rackow (theresa.kiszler@csc.fi, thomas.rackow@ecmwf.int)
+
+#### Sketch of initial activities:
+* gain access to the DestinE platform
+* identify analyses from science teams that could be executed on that platform.
+* perform analyses and compare to Hackathon models
+
+---
+### AI Representations with NVIDIA ([hk25-NVIDIA](https://github.com/digital-earths-global-hackathon/hk25-teams/tree/main/hk25-NVIDIA))
+
+NVIDIA has been exploring the use of AI to improve the workflows associated with km-scale models.  For the Hackathon they have developed a prototype emulator allows massive compression of km-scale data, which then can provide a platofrm for accelerated analysis.
+
+In this cross-cutting activity we will evaluate the capabilities and limitations of the emulator, and its ability to learn differences amond km-scale models. 
+
+**Note** Participants are asked to register for the team as early as possible so the varied skill levels can be evalauted and approrpiate activities defined. 
+
+**Coordination**: Noah Brenowitz (nbrenowitz@nvidia.com)
+
+#### Sketch of initial activities:
+* extend AI training to additional models hosted on NERSC mode
+* scale out the AI traning to other hackathon nodes and models
+* test inference of model trained on an earlier version of ICON and ERA5
+
+---
+### Feature tracking with the grassroots ([hk25-tracking](https://github.com/digital-earths-global-hackathon/hk25-teams/tree/main/hk25-tracking))
+
+Global models simulating the atmosphere at km-scale with high resolution spatio-temporal output facilitate tracking of a variety of simulated features, similar to what is done using satellite data.  For example tracking can be used to identify and follow tropical storms, mesoscale convective systems, atmospheric rivers, and so on.  For the hackathon a number of tracking tools are being adapted to work on the HEALPix output of the models.  Trackers will be introduced to related science teams by members of this cross-cutting activity.
+
+**Coordination**: Zhe Feng (zhe.feng@pnnl.gov)
+
+#### Sketch of initial activities
+- Gain familiarity with one or more trackers
+- Develop and extend their capabilities
+- Apply to output to answer questions posed by science teams.

--- a/content/homepage/crosscutting.md
+++ b/content/homepage/crosscutting.md
@@ -1,0 +1,7 @@
+---
+title: "Cross Cutting"
+weight: 4
+header_menu: true
+detailed_page_homepage_content: false
+detailed_page_path: /crosscutting/
+---

--- a/content/homepage/join.md
+++ b/content/homepage/join.md
@@ -6,22 +6,24 @@ header_menu: true
 
 There are several ways to participate in the Hackathon:
 
-* by building a science team;
-* by joining a science team;
+* by building a science team or a cross-cutting activity
+* by joining a science team and/or cross-cutting activity;
 * by exploring in loose collaboration with others.
 * work on your own.
 
 Over the course of the hackathon it is conceivable that you do all of the above. The primary platform to collaborate within teams and across nodes is built on [GitHub](https://github.com/digital-earths-global-hackathon).
 
-#### Build a Science or Tech Team
+#### Build a Science or Cross-cutting Activity
 
-To buid a team you need to define and document a scientific question, propose specific analyses, and coordinate the activities of people who join your team.  To propose a team just [**open a pull request**](https://github.com/digital-earths-global-hackathon/hk25-teams) that creates a directory, add a description in the READ.ME of your team following the template provided by the list of [existing teams]({{< ref "scienceteams.md" >}}). Please give your group an **identifier** following the pattern 'hk25-[zy*n*]'. Once you choose your identifier, please refer to your [working repository](https://github.com/digital-earths-global-hackathon/hk25-teams) in your description.
+To buid a team or activity you need to describe what it is about, propose specific analyses or tasks, and coordinate the activities of people who join your team.  The preferred way to initiate a team or an activity is to [**open a pull request**](https://github.com/digital-earths-global-hackathon/hk25-teams) that creates a directory, add a description in the READ.ME of your team following the template provided by the list of [existing teams]({{< ref "scienceteams.md" >}}). Please give your group a **unique identifier** following the pattern 'hk25-uid'. Once you choose your identifier, please refer to your [working repository](https://github.com/digital-earths-global-hackathon/hk25-teams) in your description.
 
 In the case that you have an idea that overlaps with ideas already being used to build a team, contact the team-lead of the existing team and explore the possibility of joining the team, or jointly coordinating the team.
 
-#### Join a Science or Tech Team
+For those not familiar with git, we hope you can learn to use the git repo to post an issue that describes your activity, and we will help you get started.  Of course if you have any difficulties, you can contact us directly by sending an email to {{<icon class="fa fa-envelope">}}&nbsp;[yuting.wu@mpimet.mpg.de](mailto:yuting.wu@mpimet.mpg.de)
 
-Joining a team is easy, simply review the list of [existing teams]({{< ref "scienceteams.md" >}}) and sign up for one that interests you. Signing up to a team will happen during the first day of the hackathon. For preparation, you can already explore their directory in the GitHub repository [hk25-teams](https://github.com/digital-earths-global-hackathon/hk25-teams). Just look for their identifier. Depending on how ambitious the various projects are it might be possible to join more than one team, but please clarify your role and degree of commitment with the coordinator of teams you join.
+#### Join a Science Team or Cross-cutting Activity
+
+Joining a team is easy, simply review the list of [science teams]({{< ref "scienceteams.md" >}}) or [cross-cutting activities]({{< ref "crosscutting.md" >}}) and sign up for one that interests you. Signing up to a team can happen any time.  Participation in cross-cutting activities may require pre-registration. For preparation, you can already explore the namespace allocated to teams and activities in the GitHub repository [hk25-teams](https://github.com/digital-earths-global-hackathon/hk25-teams) and [hk25-activities](https://github.com/digital-earths-global-hackathon/hk25-teams). Just look for their identifier. Depending on how ambitious the various projects are it might be possible to join more than one team, but please clarify your role and degree of commitment with the coordinator of the teams/activities that you join.
 
 #### Explore tutorials in loose collaboration
 

--- a/content/scienceteams.md
+++ b/content/scienceteams.md
@@ -6,22 +6,7 @@ header_menu: false
 
 Across the different nodes participants will be setting up science teams. These teams will address specific topics as proposed by the team lead, and attempt to engage others in joint analysis. These are open for participants at all nodes to join.
 
-Teams are given an identifier following the pattern ‘hk25-[zy*n*]’. Each team will also have an associated repo on github with the same identifier. The repo will serve as the primary basis for communication among team members.  Mattermost channels, markdown pads, and video-conference links may also serve as supplemental forms of communications, as indicated on the README to which the identifiers link.
-
----
-### Joint EarthCARE analysis ([hk25-ec1](https://github.com/digital-earths-global-hackathon/hk25-teams/tree/main/hk25-ec1))
-
-[EarthCARE](https://earth.esa.int/eogateway/missions/earthcare) is a satellite, developed by ESA, JAXA and NICT and is the sixth satellite choosen as part of ESA's Earth Explorer Programme.   It was launched on 28 May 2024, and be completing its first year in orbit at the time of the Hackathon.  It has unusual capabilities for measuring clouds, aerosols, and radiation.
-
-In this team we will analyze both EarthCARE data and the participating models along virtual EarthCARE swaths, with an initial focus on tropical deep convection as analyzed by EarthCARE, aircraft, ships and ground stations during the [ORCESTRA campaign](http://orcestra-campaign.org/), i.e., over the Tropical Atlantic in the time-period between 10 August and 30 September.
-
-**Coordination**: Bjorn Stevens (bjorn.stevens@mpimet.mpg.de)
-
-#### Sketch of initial activities:
-* extract model output along selected orbit frames
-* post-process output using model simulators
-* extract analagous EarthCARE frames and data from reanalyses.
-* perform composit analysis of various quantities.
+Science teams are given a unique identifier (uid) following the convention ‘hk25-uid’. Each team will also have a lead and an associated repo on github with the same uid. The repo will serve as the primary basis for communication among team members.  Mattermost channels, markdown pads, and video-conference links may also serve as supplemental forms of communications, as indicated on by the README for each team.
 
 ---
 ### Energetics of tropical rainbelts ([hk25-tr1](https://github.com/digital-earths-global-hackathon/hk25-teams/tree/main/hk25-tr1))
@@ -97,7 +82,7 @@ The intertropical convergence zone (ITCZ) in the eastern parts of the Pacific an
 
 ---
 
-### Mesoscale structure of stratocumulus clouds ([hk25-sc1](https://github.com/digital-earths-global-hackathon/hk25-teams/tree/main/hk25-sc1))
+### Mesoscale structure of stratocumulus ([hk25-sc1](https://github.com/digital-earths-global-hackathon/hk25-teams/tree/main/hk25-sc1))
 
 Low-level clouds over subtropical oceans are important for the energy balance of the planet and climate sensitivity. Their properties and evolution crucially depend on small scale processes. A recent examination of their climatology ([Nowak et al. 2025](https://doi.org/10.1029/2024MS004340)) in two [NextGEMS](https://nextgems-h2020.eu/) global storm-resolving models indicated realistic covariability of stratocumulus and related environmental factors, and the vertical structure of the boundary layer. How is that possible without elaborated model tuning and on the grid which is too large to resolve large turbulent eddies?
 


### PR DESCRIPTION
I separated science teams from cross cutting activities, and added content for the latter.  This will have to be updated by the respective leads.  I also clarified how to use the existing structure, including reference to backdoors for proposing teams for those unfamiliar with git workflows