### PR TITLE
Increase Hugo version

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.128.0
+      HUGO_VERSION: 0.146.7
     steps:
       - name: Install Hugo CLI
         run: |

--- a/layouts/redirect/single.html
+++ b/layouts/redirect/single.html
@@ -1,1 +1,1 @@
-{{- template "_internal/alias.html" (dict "Permalink" .Params.target) -}}
+{{- template "alias.html" (dict "Permalink" .Params.target) -}}


### PR DESCRIPTION
* Update Hugo version used in CI to latest version
* Change template name to work with latest Hugo version

_Context: the version currently used can neither be installed with `brew` nor `mamba`_