### PR TITLE
Adding model description pages to the Repository

### DIFF
--- a/content/models/icon.md
+++ b/content/models/icon.md
@@ -1,0 +1,26 @@
+
+
+# Model Name: ICON
+Team Name : MPI-Met, Hamburg
+
+Model Link: [ICON](https://icon-model.org/) 
+
+
+## Model description: 
+
+
+### Contact:
+- [Daniel Klocke](mailto:daniel.klocke@mpimet.mpg.de)
+
+## Simulation Details
+
+Simulation DOI: 
+
+- Resolution: 
+    - Horizontal: 2.5km global
+- Simulation Period: 
+
+## Notes
+
+
+

--- a/content/models/scream.md
+++ b/content/models/scream.md
@@ -1,0 +1,30 @@
+
+# Model Name: E3SM-SCREAM
+Team Name : DOE Energy Exascale Earth System Model Project
+Model Link: https://e3sm.org/
+
+
+## Model description: 
+Developed under the Energy Exascale Earth System Model (E3SM) project, the Simple Cloud-Resolving E3SM Atmosphere Model (SCREAM) is a non-hydrostatic, spectral element atmospheric model that discretizes the globe on a cubed sphere (Caldwell et al., 2021). Details of the code and components that comprise the model can be found in Donahue et al. (2024).
+
+Caldwell, P. M., C. R. Terai, B. Hillman, N. D. Keen, P. Bogenschutz, W. Lin, H. Beydoun, et al. 2021. “Convection-Permitting Simulations with the E3SM Global Atmosphere Model.” Journal of Advances in Modeling Earth Systems n/a (n/a): e2021MS002544. https://doi.org/10.1029/2021MS002544.
+
+Donahue, A. S., P. M. Caldwell, L. Bertagna, H. Beydoun, P. A. Bogenschutz, A. M. Bradley, T. C. Clevenger, et al. 2024. “To Exascale and Beyond—The Simple Cloud-Resolving E3SM Atmosphere Model (SCREAM), a Performance Portable Global Atmosphere Model for Cloud-Resolving Scales.” Journal of Advances in Modeling Earth Systems 16 (7): e2024MS004314. https://doi.org/10.1029/2024MS004314.
+
+### Contact:
+- Peter Caldwell (caldwell19@llnl.gov)
+- Chris Terai (terai1@llnl.gov)
+
+## Simulation Details
+
+- Resolution: 
+    - Horizontal: 3.25km global
+    - Vertical: 128 levels 
+    - model top of 40km
+- Free running, initialized on 2019-08-01
+- Simulation Period: 2019-08-01 to 2020-08-31
+
+## Data notes
+
+- Hourly data for rlut and pr are available at zoom level 10 and below
+- Other 3hrly variables were 'reduced' in resolution for storage to approximately 0.25˚ and are available at zoom level 8 and below

--- a/content/models/scream.md
+++ b/content/models/scream.md
@@ -17,6 +17,8 @@ Donahue, A. S., P. M. Caldwell, L. Bertagna, H. Beydoun, P. A. Bogenschutz, A. M
 
 ## Simulation Details
 
+Simulation DOI: 
+
 - Resolution: 
     - Horizontal: 3.25km global
     - Vertical: 128 levels 

--- a/content/models/um.md
+++ b/content/models/um.md
@@ -1,0 +1,25 @@
+
+# Model Name: Unified Model
+Team Name : [UK HRCM](https://hrcm.ceda.ac.uk) (MO+NCAS)
+
+Model Link: [UK HRCM](https://hrcm.ceda.ac.uk)
+
+
+## Model description: 
+
+
+### Contact:
+- [P.L. Vidale](mailto:p.l.vidale@reading.ac.uk), Huw Lewis
+
+## Simulation Details
+
+Simulation DOI: 
+
+Global and Regional Simulations are available
+
+- Resolution: 
+    - Horizontal: 2.5km global
+- Simulation Period: 
+
+## Notes
+


### PR DESCRIPTION
Started to add model description pages. Can add them for all models in the 'simulations.md' table to simplify that table. 

Question for @yu71ng (and others): how will we link to the pages in the table? Just via github link? This is probably fine, but we might want to then add a 'return' to the simulations page link at the top.

Comments welcome.  If this works I can simplify the table and we can transfer all the model information. Feel free to suggest information to be added. 