### PR TITLE
Add link to data catalog.

### DIFF
--- a/content/simulations.md
+++ b/content/simulations.md
@@ -1,5 +1,6 @@
 # Simulations and Data Availability
 
+The data are available in the [**data catalog**](https://digital-earths-global-hackathon.github.io/catalog/).
 
 This page gives the basic overview of the model simulations and available data. Details on the models are stored [here](https://github.com/digital-earths-global-hackathon/hk25/tree/main/content/models).
 


### PR DESCRIPTION
The data catalog now has a landing page, which lists all available data, and (if people add metadata to the catalog) will also contain some more description.